### PR TITLE
fix(task): set output name correctly

### DIFF
--- a/pollination/three_phase/three_phase/_daylight_matrix.py
+++ b/pollination/three_phase/three_phase/_daylight_matrix.py
@@ -55,6 +55,6 @@ class DaylightMtxRayTracing(DAG):
         return [
             {
                 'from': FluxTransfer()._outputs.flux_mtx,
-                'to': '{{name}}.dmtx'
+                'to': '{{inputs.name}}.dmtx'
             }
         ]


### PR DESCRIPTION
If we just use `{{name}}` queenbee won't know where to fetch the variable from. Or at least queenbee-argo doesn't 😅