### PR TITLE
fix(prepare-dynamic): provide optional output parameter

### DIFF
--- a/pollination/three_phase/entry.py
+++ b/pollination/three_phase/entry.py
@@ -170,7 +170,7 @@ class RecipeEntryPoint(DAG):
     @task(template=PrepareMultiphase, needs=[create_rad_folder, generate_sunpath])
     def prepare_dynamic(
         self, model=create_rad_folder._outputs.model_folder,
-        sunpath=generate_sunpath._outputs.sunpath, phase=3, cpu_count=cpu_count,
+        sunpath=generate_sunpath._outputs.sunpath, phase=5, cpu_count=cpu_count,
         cpus_per_grid=3, min_sensor_count=min_sensor_count, static='include'
     ):
         return [

--- a/pollination/three_phase/three_phase/preparation.py
+++ b/pollination/three_phase/three_phase/preparation.py
@@ -1,5 +1,4 @@
 from pollination_dsl.dag import Inputs, DAG, task, Outputs
-from pollination_dsl.dag.inputs import ItemType
 from dataclasses import dataclass
 
 from pollination.honeybee_radiance.multiphase import DaylightMatrixGrouping, \


### PR DESCRIPTION
I'm not sure if this is a limitation of Argo or something that we are not translating over but what is happening is that the function has an optional parameter that is not set to optional when translated to Argo.

```yaml
      outputs:
        parameters:
          - name: five-phase-info
            valueFrom:
              path: /workspace/five_phase.json
```

for now, I set the value for phase to 5 so the file is being generated.

cc: @AntoineDao 