### PR TITLE
fix(recipe): Fix bug when returning files

### DIFF
--- a/pollination/three_phase/three_phase/_multiply_matrix.py
+++ b/pollination/three_phase/three_phase/_multiply_matrix.py
@@ -51,7 +51,7 @@ class MultiplyMatrixDag(DAG):
         return [
             {
                 'from': MatrixMultiplicationThreePhase()._outputs.output_matrix,
-                'to': 'temp/{{identifier}}.ill'
+                'to': 'temp/{{self.identifier}}.ill'
             }
         ]
 
@@ -69,6 +69,6 @@ class MultiplyMatrixDag(DAG):
         return [
             {
                 'from': BinaryToNpy()._outputs.output_file,
-                'to': '../../results/{{light_path}}/{{state_id}}/total/{{grid_id}}.npy'
+                'to': '../../results/{{self.light_path}}/{{self.state_id}}/total/{{self.grid_id}}.npy'
             }
         ]

--- a/pollination/three_phase/three_phase/calculation.py
+++ b/pollination/three_phase/three_phase/calculation.py
@@ -119,7 +119,7 @@ class ThreePhaseMatrixCalculation(DAG):
     @task(
         template=MultiplyMatrixDag,
         loop=multiplication_info,
-        needs=[daylight_mtx_calculation],
+        needs=[calculate_view_matrix, daylight_mtx_calculation],
         sub_paths={
             'view_matrix': '{{item.vmtx}}',
             't_matrix': 'bsdf/{{item.tmtx}}',

--- a/pollination/three_phase/three_phase/preparation.py
+++ b/pollination/three_phase/three_phase/preparation.py
@@ -93,7 +93,7 @@ class ThreePhaseInputsPreparation(DAG):
         'calculation.', source='model/sender/_info.json'
     )
 
-    multiplication_info = Outputs.list(
+    multiplication_info = Outputs.file(
         description='A JSON file with matrix multiplication information.',
         source='multiplication_info.json'
     )


### PR DESCRIPTION
This should be a working release. The recipe can still be optimized by implementing GroupedDAGs, and saving the files directly to `.npy` instead of a separate task to do this.